### PR TITLE
Update genmc include path

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -109,7 +109,7 @@ libgenmc_a_SOURCES = \
 
 TESTS=scripts/fast-driver.sh scripts/randomize-driver.sh
 
-AM_CXXFLAGS = -DINCLUDE_DIR=\"$(pkgincludedir)/$(pkg)\" -DSRC_INCLUDE_DIR=\"$(abs_top_srcdir)/include\" $(COVERAGE_CXXFLAGS)
+AM_CXXFLAGS = -DINCLUDE_DIR=\"$(pkgincludedir)/$(pkg)/include\" -DSRC_INCLUDE_DIR=\"$(abs_top_srcdir)/include\" $(COVERAGE_CXXFLAGS)
 bin_PROGRAMS = genmc
 genmc_SOURCES = src/main.cpp
 genmc_LDADD = libgenmc.a -lpthread $(COVERAGE_LDFLAGS)


### PR DESCRIPTION
Genmc v0.10.0 changed the install location of the header paths relative to the installation prefix. The old location was `$prefix/include/genmc`.
The new location of the installed header files is `$prefix/include/genmc/include`, so the include dir for installations needs to be updated.