### PR TITLE
Fix false positive liveness in executions blocked for reasons other t…

### DIFF
--- a/src/GenMCDriver.cpp
+++ b/src/GenMCDriver.cpp
@@ -1400,6 +1400,8 @@ void GenMCDriver::checkLiveness()
 	/* Collect all threads blocked at spinloops */
 	std::vector<int> spinBlocked;
 	for (auto i = 0U; i < g.getNumThreads(); i++) {
+		if (llvm::isa<UserBlockLabel>(g.getLastThreadLabel(i)) || llvm::isa<HelpedCASBlockLabel>(g.getLastThreadLabel(i)) || llvm::isa<ConfirmationBlockLabel>(g.getLastThreadLabel(i)))
+			return;
 		if (llvm::isa<SpinloopBlockLabel>(g.getLastThreadLabel(i)))
 			spinBlocked.push_back(i);
 	}


### PR DESCRIPTION
…han liveness

When pruning redundant executions from the search space it can happen that some other thread is waiting for a store that would be sent by the pruning thread (doing e.g., assume(false)) if the pruning didn't happen. Since the execution should be ignored, we should not report liveness violations in such executions.